### PR TITLE
[2주차] 수식 최대화, 행렬 테두리 회전하기

### DIFF
--- a/Lv.2/거리두기확인하기/거리두기확인하기_지원.md
+++ b/Lv.2/거리두기확인하기/거리두기확인하기_지원.md
@@ -1,0 +1,68 @@
+```javascript  
+function solution(places) {
+    const personLists = places.map((val) => getPersonList(val))
+    const answer = personLists.map((val, idx) => {
+        return checkDistance(val, places[idx])
+    })
+    return answer;
+}
+
+function getPersonList(room) {
+    const personList = []
+    room.forEach((row, xIndex) => {
+        row.split('').forEach((value, yIndex) => {
+            if (value === 'P') {
+                personList.push([xIndex,yIndex])
+            }
+        })
+    })
+    return personList
+}
+
+function checkDistance(personList, room) {
+
+    for(let i=0;i<personList.length-1;++i) {
+        for(let j=i+1;j<personList.length;++j) {
+            const dist = getManhattenDistance(personList[i],personList[j])
+            if (dist === 1) {
+                return 0
+            }
+            else if (dist === 2) {
+                const xDist = Math.abs(personList[i][0] - personList[j][0])
+                const yDist = Math.abs(personList[i][1] - personList[j][1])
+                if (xDist === 2) {
+                    if (room[personList[j][0] - 1][personList[j][1]] !== 'X') {
+                        return 0
+                    }
+                }
+                else if (yDist === 2) {
+                    if (room[personList[j][0]][personList[j][1]-1] !== 'X') {
+                        return 0
+                    }
+                }
+                else {
+                    if (personList[j][1] < personList[i][1]) {
+                            if (room[personList[j][0]-1][personList[j][1]] !== 'X'
+                           || room[personList[j][0]][personList[j][1]+1] !== 'X') {
+
+                            return 0
+                        }
+                    }else {
+                            if (room[personList[j][0]][personList[j][1]-1] !== 'X'
+                           || room[personList[j][0]-1][personList[j][1]] !== 'X') {
+                            return 0
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return 1
+}
+
+function getManhattenDistance(seat1, seat2) {
+    const [r1,c1] = seat1
+    const [r2,c2] = seat2
+    return Math.abs(r1 - r2) + Math.abs(c1-c2)
+}
+```

--- a/Lv.2/수식최대화/수식최대화_지원.md
+++ b/Lv.2/수식최대화/수식최대화_지원.md
@@ -1,0 +1,71 @@
+```javascript
+function solution(expression) {
+  const permutation = [
+    ['*', '+', '-'],
+    ['*', '-', '+'],
+    ['+', '*', '-'],
+    ['+', '-', '*'],
+    ['-', '+', '*'],
+    ['-', '*', '+'],
+  ]
+  let max = 0
+  permutation.forEach((operators) => {
+    const splited = splitStr(expression)
+    let result = compute(splited, operators[0])
+    result = compute(result, operators[1])
+    result = compute(result, operators[2])
+    const price = Math.abs(result[0])
+    if (max < price) {
+      max = price
+    }
+  })
+
+  return max
+}
+
+function compute(arr, operator) {
+  const stack = []
+  arr.forEach((val) => {
+    if (stack.length === 0) {
+      stack.push(val)
+    } else {
+      if (stack[stack.length - 1] === operator) {
+        stack.pop()
+        const val1 = parseInt(stack.pop())
+        const val2 = parseInt(val)
+        if (operator === '+') {
+          const res = val1 + val2
+          stack.push(res)
+        } else if (operator === '-') {
+          const res = val1 - val2
+          stack.push(res)
+        } else {
+          const res = val1 * val2
+          stack.push(res)
+        }
+      } else {
+        stack.push(val)
+      }
+    }
+  })
+  return stack
+}
+
+function splitStr(str) {
+  const result = []
+  let tempStr = ''
+  for (const char of str) {
+    if (char === '+' || char === '-' || char === '*') {
+      if (tempStr !== '') {
+        result.push(tempStr)
+      }
+      result.push(char)
+      tempStr = ''
+    } else {
+      tempStr += char
+    }
+  }
+  result.push(tempStr)
+  return result
+}
+```

--- a/Lv.2/행렬테두리회전하기/행렬테두리회전하기_지원.md
+++ b/Lv.2/행렬테두리회전하기/행렬테두리회전하기_지원.md
@@ -1,0 +1,70 @@
+```javascript
+function solution(rows, columns, queries) {
+    const answer = []
+    let table = Array.from({length: rows+1},(rows,i)=>
+                Array.from({length: columns+1},(val,j)=>
+                    i && j ? ((i-1)*columns+j) : 0
+             ))
+    let minimum = 0;
+    const data = queries[0]
+    
+    queries.forEach(([x1,y1,x2,y2])=>{
+        const edgeVal = readEdge(x1,y1,x2,y2,table)
+        
+        const minimum = Math.min(...edgeVal)
+        edgeVal.unshift(edgeVal[edgeVal.length-1])
+        edgeVal.pop()
+        answer.push(minimum)
+        
+        table = writeEdge(x1,y1,x2,y2, edgeVal, table)
+    })
+    
+    return answer
+}
+
+function readEdge(x1,y1,x2,y2,table) {
+    let [curX,curY] = [x1,y1]
+    const edgeVal = []
+    for(let i=y1;i<=y2;++i) {
+        curY = i
+        edgeVal.push(table[curX][curY])
+    }
+    for(let i=x1+1;i<=x2;++i) {
+        curX=i
+        edgeVal.push(table[curX][curY])
+    }
+    for(let i=y2-1;i>=y1;--i) {
+        curY=i
+        edgeVal.push(table[curX][curY])
+    }
+    for(let i=x2-1;i>x1;--i) {
+        curX=i
+        edgeVal.push(table[curX][curY])
+    }
+    
+    return edgeVal
+}
+
+function writeEdge(x1,y1,x2,y2, edgeVal,table) {
+    let [curX,curY] = [x1,y1]
+    let idx = 0
+    for(let i=y1;i<=y2;++i) {
+        curY = i
+        table[curX][curY] = edgeVal[idx++]
+    }
+    for(let i=x1+1;i<=x2;++i) {
+        curX=i
+        table[curX][curY] = edgeVal[idx++]
+    }
+    for(let i=y2-1;i>=y1;--i) {
+        curY=i
+        table[curX][curY] = edgeVal[idx++]
+    }
+    for(let i=x2-1;i>x1;--i) {
+        curX=i
+        table[curX][curY] = edgeVal[idx++]
+    }
+    
+    return table
+}
+```


### PR DESCRIPTION
## 📘  제목
[Programmers/ Level 2] 수식 최대화, 행렬 테두리 회전하기
## 🔗 링크
[수식 최대화](https://programmers.co.kr/learn/courses/30/lessons/67257)
[행렬 테두리 회전하기](https://programmers.co.kr/learn/courses/30/lessons/77485)
## ✍️ 접근 방법
### 수식 최대화
- 일단 표현식 문자열 길이가 100자를 넘지 않기 때문에 무슨짓을해도 풀릴거라고 생각하고 문제 풀기 시작했습니다.
- `+,-,*` 으로 나오는 경우의 수를 다 따져도 6개밖에 되지 않기 때문에 모든 검사를 진행하기로 결정했습니다.
-  문자열을 값과 연산자로 분리한 배열을 반환해주는 함수를 구현해 첫 입력을 배열로 분리했습니다.
- 배열로 이루어진 식 계산은 Stack을 이용해서 구현했습니다.
- 음수값을 가진 숫자가 중간중간 나오는 이슈 때문에 고민했었는데, 배열을 값과 연산자로만 분리해서 해결했습니다.
   - 기존에는 음수 앞에 붙은 -가 연산자로 분리돼서 원하는 값이 안나왔었는데, 그냥 -랑 묶어서 계산후에 배열에 저장했습니다.

### 행렬 테두리 회전하기
- 처음에는 선택된 테두리의 꼭지점을 각각 한칸씩 밀고, 꼭지점을 제외한 라인을 옮겨주는 방식으로 생각했었는데 너무 소요되는 작업이 많고 시간복잡도가 과하다고 생각돼서 다른 방법을 고민했습니다. (특히 열방향 이동이 불편)
- `(x1,y1,x2,y2)`의 입력데이터를 가지고 시계방향으로 데이터를 접근하는 로직만 있다면 문제가 해결될거라고 결론내렸습니다.
- 그리고 회전은 무조건 1칸씩이므로, 시계방향 접근한 순서대로 배열에 숫자를 담고 마지막 index값을 첫번째 index에 담아서 그대로 시계방향으로 넣어줘서 문제를 해결했습니다.
   - ex) 문제 예시 Input `[8,9,10,16,22,28,27,26,20,14]` => `[14,8,9,10,16,22,28,27,26,20]` 로 바꿔서 시계방향 갱신


## 🤔후기
1. 수식 최대화 문제에서 `+,-,*`의 경우의 수를 직접 배열에 담았는데, JS에 Permutation, Combination을 생성하는 함수를 지원하고 있는지 찾아봐야 할 것 같습니다.