### PR TITLE
[2주차] 행렬 테두리 회전하기, 수식 최대화

### DIFF
--- a/Lv.2/H-Index/H-Index_계진.md
+++ b/Lv.2/H-Index/H-Index_계진.md
@@ -1,0 +1,15 @@
+```js
+// 내림 차순 정렬
+// h가 해당 인덱스의 값보다 커지면 끝
+
+function solution(citations) {
+  citations.sort((a, b) => b - a);
+  let h = 0;
+
+  while (h < citations[h]) {
+    h++;
+  }
+
+  return h;
+}
+```

--- a/Lv.2/수식최대화/수식최대화_계진.md
+++ b/Lv.2/수식최대화/수식최대화_계진.md
@@ -1,0 +1,40 @@
+```js
+const calculate = (a, b, oper) => {
+  if (oper === "+") return a + b;
+  if (oper === "*") return a * b;
+  if (oper === "-") return a - b;
+};
+
+function solution(expression) {
+  // 뒤로 갈수록 우선순위 높음
+  const prefers = [
+    ["*", "+", "-"],
+    ["*", "-", "+"],
+    ["+", "*", "-"],
+    ["+", "-", "*"],
+    ["-", "+", "*"],
+    ["-", "*", "+"],
+  ];
+  let answer = 0;
+
+  prefers.forEach((prefer) => {
+    const expOpers = expression.match(/[\*\+\-]/g); // 연산자 배열
+    const expNums = expression.match(/[0-9]{1,}/g).map((num) => Number(num)); // 피연산자 배열
+    prefer.forEach((oper) => {
+      let index = expOpers.indexOf(oper); // 현재 oper의 인덱스 찾기
+      while (index !== -1) {
+        expNums[index] = calculate(expNums[index], expNums[index + 1], oper);
+        // 사용한 연산자와 피연산자 숫자는 제거
+        expOpers.splice(index, 1);
+        expNums.splice(index + 1, 1);
+        // 인덱스 업데이트
+        index = expOpers.indexOf(oper);
+      }
+    });
+    if (answer < Math.abs(expNums[0])) {
+      answer = Math.abs(expNums[0]); // 절댓값 필요하면 적용
+    }
+  });
+  return answer;
+}
+```

--- a/Lv.2/행렬테두리회전하기/행렬테두리회전하기_계진.md
+++ b/Lv.2/행렬테두리회전하기/행렬테두리회전하기_계진.md
@@ -1,0 +1,49 @@
+```js
+function solution(rows, columns, queries) {
+  // 배열 생성
+  const arr = [];
+  let num = 1;
+  for (let i = 1; i <= rows; i++) {
+    const a = [];
+    for (let j = 1; j <= columns; j++) {
+      a.push(num);
+      num++;
+    }
+    arr.push(a);
+  }
+
+  let rotatedArr = JSON.parse(JSON.stringify(arr));
+  let min; // 각 회전마다 생기는 원소들 중 최솟값
+  const result = []; // 결과 배열
+  queries.forEach(([x1, y1, x2, y2]) => {
+    [rotatedArr, min] = rotate(rotatedArr, x1, y1, x2, y2);
+    result.push(min);
+  });
+
+  return result;
+}
+
+function rotate(arr, x1, y1, x2, y2) {
+  const rotatedArr = JSON.parse(JSON.stringify(arr));
+  const result = [];
+
+  for (let i = y1; i <= y2 - 1; i++) {
+    rotatedArr[x1 - 1][i] = arr[x1 - 1][i - 1];
+    result.push(arr[x1 - 1][i - 1]);
+  }
+  for (let i = x1; i <= x2 - 1; i++) {
+    rotatedArr[i][y2 - 1] = arr[i - 1][y2 - 1];
+    result.push(arr[i - 1][y2 - 1]);
+  }
+  for (let i = y2 - 2; i >= y1 - 1; i--) {
+    rotatedArr[x2 - 1][i] = arr[x2 - 1][i + 1];
+    result.push(arr[x2 - 1][i + 1]);
+  }
+  for (let i = x2 - 2; i >= x1 - 1; i--) {
+    rotatedArr[i][y1 - 1] = arr[i + 1][y1 - 1];
+    result.push(arr[i + 1][y1 - 1]);
+  }
+
+  return [rotatedArr, result.sort((a, b) => a - b)[0]];
+}
+```


### PR DESCRIPTION
## 행렬 테두리 회전하기
### ✍️ 접근 방법
1. 배열을 무식한 for문으로 초기화
2. query마다 생성될 배열(`rotatedArr`)을 선언하고, `rotate` 함수 실행
3. `rotate`는 돌아간 결과 배열과 돌아간 녀석들 중 최솟값을 return
4. 최솟값 배열 `result`를 return

### 🤔 후기
`rotateArr`을 처음에 [...arr]로 arr을 복사하는 미련한 짓을 해서 arr도 변경되며 값이 이상하게 바뀌는 현상을 해결 못하다가 시간을 많이 썼고, 저렇게 일일이 돌려서 혹시라도 시간초과가 날까 염려했지만 다행히도 테케는 다 통과됐습니다.. ES6와 친해지기가 참 어렵네요 ㅠㅠ

## 수식 최대화
### ✍️ 접근 방법
처음엔 `eval()`로 우선순위가 높은 식을 계산해야 하나 고민했는데, 어쨌든 계산한 결과를 계속해서 저장하고 다음 연산을 준비해야 되기 때문에 expression에 대한 연산자 배열(`expOpers`)과 피연산자 배열(`expNums`)이 필요하다는 것을 느꼈습니다. 이 아이디어만 있다면 이후는 쉬웠을 것 같은데... 떠올리지 못해서 2시간? 을 좀 넘기고 다른 풀이를 참고했습니다.
1. `prefers` 배열 선언
2. 각 `prefer` 마다 사용될 `expOpers`와 `expNums` 선언
3. `prefer`의 `oper` 연산자 마다 연산(`calculate`)을 수행 후 최댓값 return
### 🤔 후기
처음 시도했던 풀이가 막혔을 때 다른 길로 돌아가는 길을 빠르게 생각해내는 힘을 키우는 게 중요한 것 같아요